### PR TITLE
adding support for multi-team

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,30 @@
 var Botkit = require('botkit')
 
-// Expect a SLACK_TOKEN environment variable
-var slackToken = process.env.SLACK_TOKEN
-if (!slackToken) {
-  console.error('SLACK_TOKEN is required!')
-  process.exit(1)
+var token = process.env.SLACK_TOKEN
+
+var controller = Botkit.slackbot({
+  // reconnect to Slack RTM when connection goes bad
+  retry: Infinity,
+  debug: false
+})
+
+// Assume single team mode if we have a SLACK_TOKEN
+if (token) {
+  console.log('Starting in single-team mode')
+  controller.spawn({
+    token: token
+  }).startRTM(function (err, bot, payload) {
+    if (err) {
+      throw new Error(err)
+    }
+
+    console.log('Connected to Slack RTM')
+  })
+// Otherwise assume multi-team mode - setup beep boop resourcer connection
+} else {
+  console.log('Starting in Beep Boop multi-team mode')
+  require('beepboop-botkit').start(controller, { debug: true })
 }
-
-var controller = Botkit.slackbot()
-var bot = controller.spawn({
-  token: slackToken
-})
-
-bot.startRTM(function (err, bot, payload) {
-  if (err) {
-    throw new Error('Could not connect to Slack')
-  }
-})
 
 controller.on('bot_channel_join', function (bot, message) {
   bot.reply(message, "I'm here!")

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/beepboophq/node-slack-bot#readme",
   "dependencies": {
-    "botkit": "0.0.5"
+    "beepboop-botkit": "^1.4.0",
+    "botkit": "~0.1.1"
   }
 }


### PR DESCRIPTION
Baking in support for multi-team mode as well - assumes single team mode if `SLACK_TOKEN` is present, otherwise it sets up the connection the the Beep Boop resourcer for multi-team mode.

Having this baked into the starter bot seems like it will help get people going w/ a multi-team bot a little quicker with fewer hiccups.
